### PR TITLE
Create url using country

### DIFF
--- a/armrr
+++ b/armrr
@@ -30,6 +30,9 @@ if ! [[ " ${countries[*]} " == *" $country "* ]]; then
   echo "Invalid country code."
   exit 1; fi
 
+# Create url from country
+url="https://www.archlinux.org/mirrorlist/?country=$country&protocol=http&ip_version=4&use_mirror_status=on"
+
 # Download
 tmp_ml=$(mktemp --suffix=-mirrorlist)  # temporary mirrorlist
 if curl -s "$url" -o "$tmp_ml"; then


### PR DESCRIPTION
The current version of armrr isn't using the country when requesting the mirrorlist, it's **ALWAYS** using the US version!

Basically that made the script very useless

This commit generates the url using the `$country` variable.
